### PR TITLE
feat: enable process isolation headers

### DIFF
--- a/server/middleware/security-config.ts
+++ b/server/middleware/security-config.ts
@@ -39,7 +39,8 @@ export interface SecurityConfig {
     contentSecurityPolicy: {
       directives: Record<string, string[]>;
     };
-    crossOriginEmbedderPolicy: boolean;
+    crossOriginOpenerPolicy: boolean | { policy: string };
+    crossOriginEmbedderPolicy: boolean | { policy: string };
     crossOriginResourcePolicy: {
       policy: string;
     };
@@ -103,7 +104,8 @@ export const defaultSecurityConfig: SecurityConfig = {
         ...(process.env.NODE_ENV === 'production' && {'upgradeInsecureRequests': []})
       }
     },
-    'crossOriginEmbedderPolicy': false, // Disable for development compatibility
+    'crossOriginOpenerPolicy': false,
+    'crossOriginEmbedderPolicy': false,
     'crossOriginResourcePolicy': {
       'policy': 'cross-origin'
     }
@@ -148,7 +150,8 @@ export const productionSecurityConfig: SecurityConfig = {
   },
   'helmet': {
     ...defaultSecurityConfig.helmet,
-    'crossOriginEmbedderPolicy': true, // Enable in production
+    'crossOriginOpenerPolicy': { 'policy': 'same-origin' },
+    'crossOriginEmbedderPolicy': { 'policy': 'require-corp' },
     'contentSecurityPolicy': {
       'directives': {
         ...defaultSecurityConfig.helmet.contentSecurityPolicy.directives,
@@ -171,6 +174,7 @@ export const developmentSecurityConfig: SecurityConfig = {
   },
   'helmet': {
     ...defaultSecurityConfig.helmet,
+    'crossOriginOpenerPolicy': false,
     'crossOriginEmbedderPolicy': false // Disable for development
   },
   'fileUpload': {

--- a/server/middleware/security.ts
+++ b/server/middleware/security.ts
@@ -360,6 +360,8 @@ export const securityHeaders = (req: Request, res: Response, next: NextFunction)
   };
 
   // Apply helmet with dynamic CSP
+  const isProd = process.env.NODE_ENV === 'production';
+
   helmet({
     contentSecurityPolicy: {
       directives: cspDirectives
@@ -369,9 +371,9 @@ export const securityHeaders = (req: Request, res: Response, next: NextFunction)
     frameguard: { action: 'deny' },
     xssFilter: true,
     referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
-    crossOriginEmbedderPolicy: false, // Disable for development
-    crossOriginOpenerPolicy: { policy: 'same-origin' },
-    crossOriginResourcePolicy: { policy: 'same-site' }
+    crossOriginEmbedderPolicy: isProd ? { policy: 'require-corp' } : false,
+    crossOriginOpenerPolicy: isProd ? { policy: 'same-origin' } : false,
+    crossOriginResourcePolicy: { policy: isProd ? 'same-origin' : 'cross-origin' }
   })(req, res, next);
 };
 


### PR DESCRIPTION
## Summary
- enable Cross-Origin Opener/Embedder Policies in production helmet config
- conditionally apply COOP/COEP and stricter resource policy via server middleware

## Testing
- `npm test` *(fails: tsx not found)*
- `npm install --ignore-scripts` *(fails: ERESOLVE unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_68a5972405cc832596c684b89c4c408c